### PR TITLE
Erase map entry rather than clearing it, so that entry is not leaked.

### DIFF
--- a/source/threads/_win/vthread_platform.cpp
+++ b/source/threads/_win/vthread_platform.cpp
@@ -32,7 +32,10 @@ static void _addThreadToMap(VThreadID_Type threadID, HANDLE threadHandle) {
 
 static void _removeThreadFromMap(VThreadID_Type threadID) {
     VMutexLocker locker(&gWindowsThreadMapMutex, "_removeThreadFromMap");
-    gWindowsThreadIDToHandleMap[threadID] = 0;
+    WindowsThreadIDToHandleMap::iterator position = gWindowsThreadIDToHandleMap.find(threadID);
+    if (position != gWindowsThreadIDToHandleMap.end()) {
+        gWindowsThreadIDToHandleMap.erase(position);
+    }
 }
 
 static HANDLE _lookupThreadHandle(VThreadID_Type threadID) {


### PR DESCRIPTION
Fixes #28.